### PR TITLE
Add Hot Drop upgrades and enforce contract drop limits

### DIFF
--- a/BTX_CAC_Compatibility/dropslots/simgame_omni_hotdrop.json
+++ b/BTX_CAC_Compatibility/dropslots/simgame_omni_hotdrop.json
@@ -1,0 +1,19 @@
+{
+	"Description": {
+		"Id": "simgame_omni_hotdrop",
+		"Name": "HOTDROP SLOT",
+		"Details": "This type of drop slots can be used for rapid deployment during mission.",
+		"Icon": ""
+	},
+	"Tags": [
+		"can_drop_generic_mech",
+		"can_drop_generic_vehicle"
+	],
+	"Decorations": [
+		"decoration_slot_hotdrop"
+	],
+	"Order": 102,
+	"StatName": "BiggerDrops_HotDropMechSlots",
+	"HotDrop": true,
+	"UseMaxUnits": true
+}

--- a/BTX_CAC_Compatibility/mod.json
+++ b/BTX_CAC_Compatibility/mod.json
@@ -30,6 +30,8 @@
 	"DLL": "BTX_CAC_CompatibilityDll.dll",
 	"Settings": {
 		"FixDropslotsInOldSaves": true,
+		"EnforceContractLimits": true,
+		"Use4LimitOnAllStoryMissions": false,
 		"Use4LimitOnContractIds": [
 			"uw1_4_destroyBase",
 			"tournament_1_3wayBattle",

--- a/BTX_CAC_CompatibilityDll/BTX_CAC_CompatibilityDll/ContractOverride_FixMaxPlayers.cs
+++ b/BTX_CAC_CompatibilityDll/BTX_CAC_CompatibilityDll/ContractOverride_FixMaxPlayers.cs
@@ -3,37 +3,61 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.Reflection;
 using HarmonyLib;
 using BattleTech;
 using BattleTech.Framework;
 using System.Reflection.Emit;
+using BattleTech.UI;
 
 namespace BTX_CAC_CompatibilityDll
 {
     [HarmonyPatch(typeof(ContractOverride), "FromJSONFull")]
-    class ContractOverride_FromJSONFull
+    [HarmonyPatch(typeof(ContractOverride), "FullRehydrate")]
+    public class ContractOverride_FixMaxPlayers
     {
         public static void Postfix(ContractOverride __instance)
         {
-            PatchContract(__instance);
-        }
+            if (Main.Sett.Use4LimitOnAllStoryMissions && IsAnyStoryContract(__instance))
+                return;
 
-        internal static void PatchContract(ContractOverride __instance)
-        {
-            if (__instance.maxNumberOfPlayerUnits == 4 && !Main.Sett.Use4LimitOnContractIds.Contains(__instance.ID))
+            if (__instance.maxNumberOfPlayerUnits == 4 && !IsContractLimitedTo4Units(__instance))
             {
-                __instance.maxNumberOfPlayerUnits = 8;
+                __instance.maxNumberOfPlayerUnits = 12;
             }
         }
+
+        private static bool IsAnyStoryContract(ContractOverride contractOverride) =>
+            contractOverride.contractDisplayStyle is ContractDisplayStyle.BaseCampaignStory or ContractDisplayStyle.BaseCampaignRestoration;
+
+        private static bool IsContractLimitedTo4Units(ContractOverride contractOverride) =>
+            Main.Sett.Use4LimitOnContractIds.Contains(contractOverride.ID);
     }
 
-
-    [HarmonyPatch(typeof(ContractOverride), "FullRehydrate")]
-    class ContractOverride_FullRehydrate
+    [HarmonyPatch(typeof(LanceConfiguratorPanel), "LoadLanceConfiguration")]
+    public static class LanceConfiguratorPanel_LoadLanceConfiguration
     {
-        public static void Postfix(ContractOverride __instance)
+        [HarmonyPrepare]
+        public static bool Prepare() => Main.Sett.EnforceContractLimits;
+
+        [HarmonyPostfix]
+        [HarmonyPriority(Priority.Last)]
+        public static void Postfix(LanceConfiguratorPanel __instance)
         {
-            ContractOverride_FromJSONFull.PatchContract(__instance);
+            var loadoutSlotsField = typeof(LanceConfiguratorPanel).GetField("loadoutSlots", BindingFlags.Instance | BindingFlags.NonPublic);
+            if (loadoutSlotsField == null) return;
+
+            var loadoutSlots = (LanceLoadoutSlot[])loadoutSlotsField.GetValue(__instance);
+            if (loadoutSlots != null)
+            {
+                for (int i = 0; i < loadoutSlots.Length; i++)
+                {
+                    bool locked = i >= __instance.activeContract.Override.maxNumberOfPlayerUnits;
+                    loadoutSlots[i].SetLockState(locked ?
+                        LanceLoadoutSlot.LockState.Full :
+                        LanceLoadoutSlot.LockState.Unlocked);
+                }
+            }
         }
     }
 }

--- a/BTX_CAC_CompatibilityDll/BTX_CAC_CompatibilityDll/Settings.cs
+++ b/BTX_CAC_CompatibilityDll/BTX_CAC_CompatibilityDll/Settings.cs
@@ -10,6 +10,8 @@ namespace BTX_CAC_CompatibilityDll
     class Settings
     {
         public bool LogLevelLog = true;
+        public bool EnforceContractLimits = true;
+        public bool Use4LimitOnAllStoryMissions = false;
         public string[] Use4LimitOnContractIds = new string[] { };
         public bool MECompat = false;
         public bool FixDropslotsInOldSaves = true;

--- a/BTX_CAC_CompatibilityDll/BTX_CAC_CompatibilityDll/SimGameState_InitStats.cs
+++ b/BTX_CAC_CompatibilityDll/BTX_CAC_CompatibilityDll/SimGameState_InitStats.cs
@@ -32,23 +32,41 @@ namespace BTX_CAC_CompatibilityDll
 
         public static void Postfix(SimGameState __instance)
         {
-            bool update = false;
+            int updated = 0;
             if (__instance.CompanyStats.GetValue<int>("BiggerDrops_BaseMechSlots") != 4)
             {
                 __instance.CompanyStats.RemoveStatistic("BiggerDrops_BaseMechSlots");
                 __instance.CompanyStats.AddStatistic("BiggerDrops_BaseMechSlots", 4);
-                update = true;
+                updated++;
             }
             int u = GetUpgradeStat(__instance, "BiggerDrops_AdditionalMechSlots");
             if (__instance.CompanyStats.GetValue<int>("BiggerDrops_AdditionalMechSlots") != u)
             {
                 __instance.CompanyStats.RemoveStatistic("BiggerDrops_AdditionalMechSlots");
                 __instance.CompanyStats.AddStatistic("BiggerDrops_AdditionalMechSlots", u);
-                update = true;
+                updated++;
             }
-            if (update)
-                DropManager.UpdateCULances();
-            Main.Log.Log($"dropslot stats: BiggerDrops_BaseMechSlots: {__instance.CompanyStats.GetValue<int>("BiggerDrops_BaseMechSlots")}, BiggerDrops_AdditionalMechSlots: {__instance.CompanyStats.GetValue<int>("BiggerDrops_AdditionalMechSlots")}, Upgrades: {u}");
+            int u2 = GetUpgradeStat(__instance, "BiggerDrops_HotDropMechSlots");
+            if (__instance.CompanyStats.GetValue<int>("BiggerDrops_HotDropMechSlots") != u2)
+            {
+                __instance.CompanyStats.RemoveStatistic("BiggerDrops_HotDropMechSlots");
+                __instance.CompanyStats.AddStatistic("BiggerDrops_HotDropMechSlots", u2);
+                updated++;
+            }
+            int u3 = BiggerDrops.BiggerDrops.settings.defaultMaxTonnage + GetUpgradeStat(__instance, "BiggerDrops_MaxTonnage");
+            if (__instance.CompanyStats.GetValue<int>("BiggerDrops_MaxTonnage") != u3)
+            {
+                __instance.CompanyStats.RemoveStatistic("BiggerDrops_MaxTonnage");
+                __instance.CompanyStats.AddStatistic("BiggerDrops_MaxTonnage", u3);
+                updated++;
+            }
+            if (updated >=1) DropManager.UpdateCULances();
+            Main.Log.Log($"Dropslot stats: " +
+                $"BiggerDrops_BaseMechSlots: {__instance.CompanyStats.GetValue<int>("BiggerDrops_BaseMechSlots")}, " +
+                $"BiggerDrops_AdditionalMechSlots: {__instance.CompanyStats.GetValue<int>("BiggerDrops_AdditionalMechSlots")}, " +
+                $"BiggerDrops_HotDropMechSlots: {__instance.CompanyStats.GetValue<int>("BiggerDrops_HotDropMechSlots")}, " +
+                $"BiggerDrops_MaxTonnage: {__instance.CompanyStats.GetValue<int>("BiggerDrops_MaxTonnage")}"
+            );
         }
 
         public static void Patch(Harmony h)

--- a/BiggerDrops/ShipUpgradeCategory.json
+++ b/BiggerDrops/ShipUpgradeCategory.json
@@ -1,0 +1,19 @@
+{
+  "enumerationValueList": [
+    {
+      "ID": 50,
+      "Name": "BDDropTonnage",
+      "FriendlyName": "Max Drop Tonnage"
+    },
+    {
+      "ID": 51,
+      "Name": "BDMechControl",
+      "FriendlyName": "Additional Drop Pods"
+    },
+    {
+      "ID": 52,
+      "Name": "BDMechDrops",
+      "FriendlyName": "Additional Mech Drops"
+    }
+  ]
+}

--- a/BiggerDrops/settings.json
+++ b/BiggerDrops/settings.json
@@ -8,10 +8,10 @@
   "showAdditionalArgoUpgrades" : true,
   "argoUpgradeName" : "Command & Control",
   "argoUpgradeCategory1Name" : "Drop Size",
-  "argoUpgradeCategory2Name" : "Mech Control",
+  "argoUpgradeCategory2Name" : "Drop Pods",
   "argoUpgradeCategory3Name" : "Drop Tonnage",
   "limitFlashpointDrop" : false,
-  "CuV2FormationSize": 8,
+  "CuV2FormationSize": 4,
   "CuV2InitialSlots": [
     "simgame_omni_slot",
     "simgame_omni_slot",

--- a/BiggerDrops/shipUpgrades/argoUpgrade_PilotSlot.json
+++ b/BiggerDrops/shipUpgrades/argoUpgrade_PilotSlot.json
@@ -1,0 +1,42 @@
+{
+  "Description": {
+    "Cost": 0,
+    "Rarity": 0,
+    "Purchasable": true,
+    "UIName": "",
+    "Id": "argoUpgrade_PilotSlot",
+    "Name": "Drop Pod Launch Systems",
+    "Details": "<b><color=#F79232>Enables to Hot Drop 1 additional Mech.</color></b>\n\nCommander, while my techs were rebuilding the bays on the new Leopard, we found the remnants of the standard Drop Pod launch systems. Most Leopards are supposed to have them, but these are shot to hell. The primary launch actuators are missing, and the pod's data and power connectors are corroded beyond repair. I can get the team to custom-machine the parts to make it operational again. It'll let us perform a single, by-the-book hot drop, just as the manual intended.",
+    "Icon": "uixSvgIcon_shipUpgrade_automation"
+  },
+  "Illustration": "uixTxrSpot_YangWorking",
+  "Location": "UNKNOWN",
+  "shipUpgradeCategoryID": "BDMechControl",
+  "AssignedCastDefId": "castDef_YangDefault",
+  "AssignedCastDescription": "This will let us insert a 'Mech from high altitude without having to land the Leopard first. A true hot drop, right into the thick of battle.",
+  "RequiredModules": {
+    "items": [
+      "argoUpgrade_JunkyardLeopard",
+      "argoUpgrade_DropSlot"
+    ],
+    "tagSetSourceFile": ""
+  },
+  "Requirements": [],
+  "TechCost": 6,
+  "PurchaseCost": 180000,
+  "AdditionalCost": 3500,
+  "Tags": {
+    "items": [
+      "JunkyardLeopard_Pilotslot"
+    ],
+    "tagSetSourceFile": ""
+  },
+  "Stats": [
+    {
+      "typeString": "System.Int32",
+      "name": "BiggerDrops_HotDropMechSlots",
+      "value": 1,
+      "valueConstant": ""
+    }
+  ]
+}

--- a/BiggerDrops/shipUpgrades/argoUpgrade_PilotSlot1.json
+++ b/BiggerDrops/shipUpgrades/argoUpgrade_PilotSlot1.json
@@ -1,0 +1,43 @@
+{
+  "Description": {
+    "Cost": 0,
+    "Rarity": 0,
+    "Purchasable": true,
+    "UIName": "",
+    "Id": "argoUpgrade_PilotSlot1",
+    "Name": "Drop Pod Launch Systems",
+    "Details": "<b><color=#F79232>Enables to Hot Drop 1 additional Mech.</color></b>\n\nThe first Drop Pod launcher is back online, Boss. Getting a second one running is less about fabrication and more about logistics. The control systems use a number of rare components that we just can't make here. We'll have to source them from a specialized supplier. It won't be cheap, but securing a batch will let us refit the second bay and give us a stockpile for the rest of the project.",
+    "Icon": "uixSvgIcon_shipUpgrade_automation"
+  },
+  "Illustration": "uixTxrSpot_YangWorking",
+  "Location": "UNKNOWN",
+  "shipUpgradeCategoryID": "BDMechControl",
+  "AssignedCastDefId": "castDef_DariusDefault",
+  "AssignedCastDescription": "It's a significant expense, Commander, but having another 'Mech available for rapid deployment will open up new tactical possibilities.",
+  "RequiredModules": {
+    "items": [
+      "argoUpgrade_JunkyardLeopard",
+      "argoUpgrade_DropSlot1",
+      "argoUpgrade_PilotSlot"
+    ],
+    "tagSetSourceFile": ""
+  },
+  "Requirements": [],
+  "TechCost": 7,
+  "PurchaseCost": 210000,
+  "AdditionalCost": 4000,
+  "Tags": {
+    "items": [
+      "JunkyardLeopard_Pilotslot1"
+    ],
+    "tagSetSourceFile": ""
+  },
+  "Stats": [
+    {
+      "typeString": "System.Int32",
+      "name": "BiggerDrops_HotDropMechSlots",
+      "value": 1,
+      "valueConstant": ""
+    }
+  ]
+}

--- a/BiggerDrops/shipUpgrades/argoUpgrade_PilotSlot2.json
+++ b/BiggerDrops/shipUpgrades/argoUpgrade_PilotSlot2.json
@@ -1,0 +1,44 @@
+{
+  "Description": {
+    "Cost": 0,
+    "Rarity": 0,
+    "Purchasable": true,
+    "UIName": "",
+    "Id": "argoUpgrade_PilotSlot2",
+    "Name": "Drop Pod Launch Systems",
+    "Details": "<b><color=#F79232>Enables to Hot Drop 1 additional Mech.</color></b>\n\nFixing the hardware is one thing, Boss, but the Leopard's original targeting computer is fried. Right now, we're dropping 'dumb'—the pod gets the BattleMechto the ground safely, but the landing zone is a guess at best. We'll need to install a modern guidance system to give our hot drops some much-needed precision. That'll let us bring the third launcher online and start dropping our 'Mechs exactly where you want them.",
+    "Icon": "uixSvgIcon_shipUpgrade_automation"
+  },
+  "Illustration": "uixTxrSpot_YangWorking",
+  "Location": "UNKNOWN",
+  "shipUpgradeCategoryID": "BDMechControl",
+  "AssignedCastDefId": "castDef_SumireDefault",
+  "AssignedCastDescription": "Knowing our pilots can land on a precise, chosen location instead of dropping blind… That makes all the difference, Commander.",
+  "RequiredModules": {
+    "items": [
+      "argoUpgrade_JunkyardLeopard",
+      "argoUpgrade_DropSlot2",
+      "argoUpgrade_PilotSlot1",
+      "argoUpgrade_pod2"
+    ],
+    "tagSetSourceFile": ""
+  },
+  "Requirements": [],
+  "TechCost": 8,
+  "PurchaseCost": 240000,
+  "AdditionalCost": 4000,
+  "Tags": {
+    "items": [
+      "JunkyardLeopard_Pilotslot2"
+    ],
+    "tagSetSourceFile": ""
+  },
+  "Stats": [
+    {
+      "typeString": "System.Int32",
+      "name": "BiggerDrops_HotDropMechSlots",
+      "value": 1,
+      "valueConstant": ""
+    }
+  ]
+}

--- a/BiggerDrops/shipUpgrades/argoUpgrade_PilotSlot3.json
+++ b/BiggerDrops/shipUpgrades/argoUpgrade_PilotSlot3.json
@@ -1,0 +1,44 @@
+{
+  "Description": {
+    "Cost": 0,
+    "Rarity": 0,
+    "Purchasable": true,
+    "UIName": "",
+    "Id": "argoUpgrade_PilotSlot3",
+    "Name": "Drop Pod Launch Systems",
+    "Details": "<b><color=#F79232>Enables to Hot Drop 1 additional Mech.</color></b>\n\nAlright, Boss, all the individual launchers are ready, but dropping a full lance at once is tricky. The ship's master launch controller—the system that makes sure all the pods release without interfering or colliding with each other—is still offline. We need to get it installed and calibrated to synchronize the whole system. Once that's done, the Leopard will be fully certified for safe, lance-scale hot drops.",
+    "Icon": "uixSvgIcon_shipUpgrade_automation"
+  },
+  "Illustration": "uixTxrSpot_YangWorking",
+  "Location": "UNKNOWN",
+  "shipUpgradeCategoryID": "BDMechControl",
+  "AssignedCastDefId": "castDef_DariusDefault",
+  "AssignedCastDescription": "With two Leopards fully operational, Commander, our tactical reach across the battlefield just got a whole lot bigger.",
+  "RequiredModules": {
+    "items": [
+      "argoUpgrade_JunkyardLeopard",
+      "argoUpgrade_DropSlot3",
+      "argoUpgrade_PilotSlot2",
+      "argoUpgrade_pod3"
+    ],
+    "tagSetSourceFile": ""
+  },
+  "Requirements": [],
+  "TechCost": 9,
+  "PurchaseCost": 270000,
+  "AdditionalCost": 4500,
+  "Tags": {
+    "items": [
+      "JunkyardLeopard_Pilotslot3"
+    ],
+    "tagSetSourceFile": ""
+  },
+  "Stats": [
+    {
+      "typeString": "System.Int32",
+      "name": "BiggerDrops_HotDropMechSlots",
+      "value": 1,
+      "valueConstant": ""
+    }
+  ]
+}

--- a/BiggerDrops/statdesc/SimGameStatDesc_BiggerDrops_HotDropMechSlots.json
+++ b/BiggerDrops/statdesc/SimGameStatDesc_BiggerDrops_HotDropMechSlots.json
@@ -1,0 +1,18 @@
+{
+    "Description": {
+        "Id": "SimGameStatDesc_BiggerDrops_HotDropMechSlots",
+        "Name": "BiggerDrops_HotDropMechSlots",
+        "Details": "",
+        "Icon": null
+    },
+    "setResult": "Increases Size of Hot Drop Lance {RES_VALUE.ToString}%",
+    "positiveResult": "Increases Size of Hot Drop Lance {RES_VALUE.ToString}%",
+    "negativeResult": "Decreases Size of Hot Drop Lance {RES_VALUE.ToString}%",
+    "temporalSetResult": "",
+    "temporalPositiveResult": "",
+    "temporalNegativeResult": "",
+    "infinitiveSetResult": "Size of Hot Drop Lance {RES_VALUE.ToString}%",
+    "infinitivePositiveResult": "Increases Size of Hot Drop Lance {RES_VALUE.ToString}%",
+    "infinitiveNegativeResult": "Decreases Size of Hot Drop Lance {RES_VALUE.ToString}%",
+    "hidden": true
+}


### PR DESCRIPTION
EnforceContractLimits prevents dropping more mechs than a contract allows. I've also added the ability to change the default max tonnage and limit campaign missions to four mechs.